### PR TITLE
Set bash -e as build node shell command

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,42 +21,42 @@ node("docker") {
                 --env https_proxy=${env.https_proxy} \
             ")
         sh "docker cp ${project} ${container_name}:/home/jenkins/${project}"
-        sh """docker exec --user root ${container_name} bash -c \"
+        sh """docker exec --user root ${container_name} bash -e -c \"
             chown -R jenkins.jenkins /home/jenkins/${project}
         \""""
-        
+
         stage("Create virtualenv") {
-            sh """docker exec ${container_name} bash -c \"
+            sh """docker exec ${container_name} bash -e -c \"
                 cd ${project}
                 python3.6 -m venv build_env
             \""""
         }
-        
+
         stage("Install requirements") {
-            sh """docker exec ${container_name} bash -c \"
+            sh """docker exec ${container_name} bash -e -c \"
                 cd ${project}
                 build_env/bin/pip --proxy ${http_proxy} install --upgrade pip
                 build_env/bin/pip --proxy ${http_proxy} install -r requirements.txt
             \""""
         }
-        
+
         stage("Build C++ code") {
-            sh """docker exec ${container_name} bash -c \"
+            sh """docker exec ${container_name} bash -e -c \"
                 cd ${project}
                 cmake3 cpp_src -DCMAKE_BUILD_TYPE=Release
                 make
             \""""
         }
-        
+
         stage("Create package") {
-            sh """docker exec ${container_name} bash -c \"
+            sh """docker exec ${container_name} bash -e -c \"
                 cd ${project}
                 build_env/bin/pyinstaller -w OHWR_ADC_Tester.py
             \""""
         }
-        
+
         stage("Archive package") {
-            sh """docker exec ${container_name} bash -c \"
+            sh """docker exec ${container_name} bash -e -c \"
                 cd ${project}
                 tar czvf OHWR_ADC_Tester.tar.gz -C dist/ OHWR_ADC_Tester/
             \""""


### PR DESCRIPTION
This makes scripts exit with an error after the first failing command
and does not require using && to continue lines in scripts.